### PR TITLE
2015-16 Genesis min steer speed update

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -60,7 +60,7 @@ class CarInterface(CarInterfaceBase):
     ret.smoothSteer.driverAngleWait = float( Params().get("OpkrDriverAngleWait", encoding="utf8") )  #0.001
     #ret.steeringPressed
     #ret.maxSteeringAngleDeg = 90
-    ret.minSteerSpeed = 16.67 # m/s
+    ret.minSteerSpeed = 15.42 # m/s
 
     # Most Hyundai car ports are community features for now
     ret.pcmCruise = not ret.radarOffCan

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -130,7 +130,7 @@ CAR_INFO: Dict[str, Union[HyundaiCarInfo, List[HyundaiCarInfo]]] = {
   CAR.MOHAVE_HM: HyundaiCarInfo("Kia Mohave 2019"),
 
   # genesis
-  CAR.GENESIS_DH: HyundaiCarInfo("Genesis 2015-2016", min_enable_speed=19 * CV.MPH_TO_MS, harness=Harness.hyundai_j),
+  CAR.GENESIS_DH: HyundaiCarInfo("Genesis 2015-2016", min_enable_speed=15 * CV.MPH_TO_MS, harness=Harness.hyundai_j),
   CAR.GENESIS_G70_IK: HyundaiCarInfo("Genesis G70 2018", "All", harness=Harness.hyundai_f),
   CAR.GENESIS_G70_2020: HyundaiCarInfo("Genesis G70 2020", "All", harness=Harness.hyundai_f),
   CAR.GENESIS_G80_DH: HyundaiCarInfo("Genesis G80 2017", "All", harness=Harness.hyundai_h),

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -241,8 +241,8 @@ def below_steer_speed_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: 
   return Alert(
     f"Steer Unavailable Below {get_display_speed(CP.minSteerSpeed, metric)}",
     "",
-    AlertStatus.userPrompt, AlertSize.small,
-    Priority.MID, VisualAlert.none, AudibleAlert.prompt, 0.4)
+    AlertStatus.userPrompt, AlertSize.none,
+    Priority.MID, VisualAlert.none, AudibleAlert.none, 0.4)
 
 
 def calibration_incomplete_alert(CP: car.CarParams, sm: messaging.SubMaster, metric: bool, soft_disable_time: int) -> Alert:


### PR DESCRIPTION
This change enables lateral control to start @ 34 mph and also removes the annoying below steer speed warning.  